### PR TITLE
README: Remove line about pip requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ correctly from Hippo (missing extension in filename, for example)
 
 Requires https://github.com/chrisboyke/config_util
 
-Also, install standard requirements via:
-
-pip3 install -r requirements.txt
-
 ## Usage
 extract.py <ini_file>
 


### PR DESCRIPTION
There is no requirements.txt, so I don't think this instruction belongs in the README.