### PR TITLE
Remove filecmp from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 lxml
 requests
 configparser
-filecmp


### PR DESCRIPTION
This failed to resolve as a requirement when I tried to run pip3.  Since it is a standard library in python3, I don't believe it needs to be installed as a requirement.